### PR TITLE
addition to format_p

### DIFF
--- a/R/print_pvalue.R
+++ b/R/print_pvalue.R
@@ -4,6 +4,9 @@
 #' 
 #' @param pvalues The p-values
 #' @param decimals The number of decimals to be printed
+#' @param numbers_only An integer indicating whether the p-values
+#'                     should be printed whithout the accompanying p.
+#'                     Defaults to \code{FALSE}.
 #' @return A string representation of the p value to be used in Rmarkdown
 #'   documents.
 #' 
@@ -21,8 +24,13 @@
 #' format_p(c(.999, .9999, 1))
 #'
 
-format_p <- function(pvalues, decimals = 3) {
-  return(vectorize_print(pvalues, decimals, format_p_))
+format_p <- function(pvalues, decimals = 3, numbers_only = FALSE) {
+  if (numbers_only == FALSE) {
+    return(vectorize_print(pvalues, decimals, format_p_))
+  } else {
+    return(vectorize_print(pvalues, decimals, format_p_no))
+  }
+
 }
 
 format_p_ <- function(pvalue, decimals) {
@@ -37,5 +45,20 @@ format_p_ <- function(pvalue, decimals) {
   }
   if (pvalue < 0.01 & decimals <= 2) p <- "$p < .01$"
   if (pvalue < 0.001) p <- "$p < .001$"
+  return(p)
+}
+
+format_p_no <- function(pvalue, decimals) {
+  if (pvalue < 0 | pvalue > 1)
+    stop("p value is smaller than 0 or larger than 1")
+  if (pvalue >= 0.001) {
+    p <- paste0("$", decimals_only(pvalue, decimals), "$")
+  }
+  ## Special case: p-value is 1 (or the rounded p-value is 1)
+  if (round(pvalue, decimals) == 1) {
+    p <- paste0("$> .", paste0(rep("9", decimals), collapse = ""), "$")
+  }
+  if (pvalue < 0.01 & decimals <= 2) p <- "$< .01$"
+  if (pvalue < 0.001) p <- "$< .001$"
   return(p)
 }

--- a/man/format_p.Rd
+++ b/man/format_p.Rd
@@ -4,12 +4,16 @@
 \alias{format_p}
 \title{Format a p-value according to APA standards}
 \usage{
-format_p(pvalues, decimals = 3)
+format_p(pvalues, decimals = 3, numbers_only = FALSE)
 }
 \arguments{
 \item{pvalues}{The p-values}
 
 \item{decimals}{The number of decimals to be printed}
+
+\item{numbers_only}{An integer indicating whether the p-values
+should be printed whithout the accompanying p.
+Defaults to \code{FALSE}.}
 }
 \value{
 A string representation of the p value to be used in Rmarkdown


### PR DESCRIPTION
- p values can be printed as formatted numbers, but without "p (=)" in front of them via an additional argument (default is `FALSE` so the in-text version is printed)
- e.g. useful for tables