### PR TITLE
Cohen's d using effectsize instead of effsize

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
     spgs
 Encoding: UTF-8
 LazyLoad: yes
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/man/print_anova.Rd
+++ b/man/print_anova.Rd
@@ -4,8 +4,7 @@
 \alias{print_anova}
 \title{Print the results of an \code{afex} ANOVA}
 \usage{
-print_anova(afex_object, italic_eta = TRUE, decimals = 2,
-  decimals_p = 3)
+print_anova(afex_object, italic_eta = TRUE, decimals = 2, decimals_p = 3)
 }
 \arguments{
 \item{afex_object}{An object returned by one of \code{afex}'s ANOVA

--- a/man/print_chi2.Rd
+++ b/man/print_chi2.Rd
@@ -4,8 +4,7 @@
 \alias{print_chi2}
 \title{Print the results of a chi-square test}
 \usage{
-print_chi2(x, es = TRUE, correct = FALSE, decimals = 2,
-  decimals_p = 3)
+print_chi2(x, es = TRUE, correct = FALSE, decimals = 2, decimals_p = 3)
 }
 \arguments{
 \item{x}{A contingency table (passed as \code{table} or \code{matrix}) or

--- a/man/print_mean_sd.Rd
+++ b/man/print_mean_sd.Rd
@@ -4,8 +4,14 @@
 \alias{print_mean_sd}
 \title{Print mean and standard deviation}
 \usage{
-print_mean_sd(x, decimals_M = 2, decimals_SD = 2, parentheses = TRUE,
-  short = FALSE, na.rm = FALSE)
+print_mean_sd(
+  x,
+  decimals_M = 2,
+  decimals_SD = 2,
+  parentheses = TRUE,
+  short = FALSE,
+  na.rm = FALSE
+)
 }
 \arguments{
 \item{x}{a vector of the sample the statistics should be printed for.}

--- a/man/print_ttest.Rd
+++ b/man/print_ttest.Rd
@@ -10,8 +10,8 @@ print_ttest(t_object, d_object = NULL, decimals = 2, decimals_p = 3)
 \item{t_object}{An object of class "htest" returned by 
 \code{\link{t.test}}.}
 
-\item{d_object}{An object of class "effsize" returned by 
-\code{\link[effsize]{cohen.d}} from package \code{effsize}. 
+\item{d_object}{An effect size table returned by 
+\code{\link[effectsize]{cohens_d}} from package \code{effectsize}. 
 Optional argument.}
 
 \item{decimals}{How many decimals should be printed for the t-value
@@ -28,22 +28,22 @@ A string describing the t-test; to be
 Print the results of a t-test
 }
 \details{
-To use this function, you need to install the R package \code{effsize}
+To use this function, you need to install the R package \code{effectsize}
 to compute Cohen's d; pass this object as the second argument.
 }
 \examples{
 
 ttest <- t.test(1:10, y = c(7:20), var.equal = TRUE)
-library("effsize") # for Cohen's d
-cohend <- cohen.d(1:10, c(7:20))
+library("effectsize") # for Cohen's d
+cohend <- cohens_d(1:10, c(7:20))
 print_ttest(ttest, cohend) # include this call in Rmd inline code
 
 # An example for paired data:
 data(sleep) # ?sleep
 tt <- t.test(sleep$extra[sleep$group == 1], 
              sleep$extra[sleep$group == 2], paired = TRUE)
-cd <- cohen.d(sleep$extra[sleep$group == 1], 
-              sleep$extra[sleep$group == 2], paired = TRUE)
+cd <- cohens_d(sleep$extra[sleep$group == 1], 
+               sleep$extra[sleep$group == 2], paired = TRUE)
 print_ttest(tt, cd)
 # effect size object can be left out:
 print_ttest(tt)

--- a/man/print_wilcoxon_rs.Rd
+++ b/man/print_wilcoxon_rs.Rd
@@ -4,9 +4,18 @@
 \alias{print_wilcoxon_rs}
 \title{Print the results of a Wilcoxon rank sum test (Mann-Whitney-U test)}
 \usage{
-print_wilcoxon_rs(wc_object, decimals_p = 3, consistent = NULL,
-  group1 = NULL, group2 = NULL, groupvar = NULL, effsize = NULL,
-  neg = FALSE, N = NULL, decimals_eff = NULL)
+print_wilcoxon_rs(
+  wc_object,
+  decimals_p = 3,
+  consistent = NULL,
+  group1 = NULL,
+  group2 = NULL,
+  groupvar = NULL,
+  effsize = NULL,
+  neg = FALSE,
+  N = NULL,
+  decimals_eff = NULL
+)
 }
 \arguments{
 \item{wc_object}{an object returned by \code{\link{wilcox.test}}}


### PR DESCRIPTION
- `print_ttest()` now expects an object from the function `cohens_d()` from the package `effectsize` instead of from the function `cohen.d()` from the package `effsize`.
- Formatting in some documentation files changed because of a more recend roxygen version.