### PR TITLE
make latex optional when printing p-values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,4 @@ Suggests:
     spgs
 Encoding: UTF-8
 LazyLoad: yes
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/print_pvalue.R
+++ b/R/print_pvalue.R
@@ -5,8 +5,10 @@
 #' @param pvalues The p-values
 #' @param decimals The number of decimals to be printed
 #' @param numbers_only Logical, indicates whether the p-values
-#'                     should be printed whithout the accompanying p.
+#'                     should be printed without the accompanying p.
 #'                     Defaults to \code{FALSE}. 
+#' @param latex Logical, indicates whether the p-values should be printed with 
+#'              or without \code{$} around it. Defaults to \code{TRUE}.
 #'
 #' @return A string representation of the p value to be used in Rmarkdown
 #'   documents.
@@ -20,17 +22,20 @@
 #' format_p(0.000001231)
 #' format_p(0.000001231, decimals = 2)
 #' format_p(0.3123, decimals = 2)
+#' format_p(0.3123, latex = FALSE)
 #' # Format several p-values with one function call
 #' format_p(c(0.3123, 0.001, 0.00001, 0.19))
 #' format_p(c(.999, .9999, 1))
 #' format_p(c(0.3123, 0.001, 0.00001, 0.19, .99999), numbers_only = TRUE)
 #'
 
-format_p <- function(pvalues, decimals = 3, numbers_only = FALSE) {
-  return(vectorize_print(pvalues, decimals, format_p_, numbers_only))
+format_p <- function(
+    pvalues, decimals = 3, numbers_only = FALSE, latex = TRUE
+) {
+  return(vectorize_print(pvalues, decimals, format_p_, numbers_only, latex))
 }
 
-format_p_ <- function(pvalue, decimals, numbers_only) {
+format_p_ <- function(pvalue, decimals, numbers_only, latex) {
   if (is.na(pvalue)) {
     return(as.character(NA))
   }
@@ -38,22 +43,24 @@ format_p_ <- function(pvalue, decimals, numbers_only) {
     stop("p value is smaller than 0 or larger than 1")
   }
   if (pvalue >= 0.001) {
-    p <- paste0("$p = ", decimals_only(pvalue, decimals), "$")
+    p <- paste0("p = ", decimals_only(pvalue, decimals))
   }
   ## Special case: p-value is 1 (or the rounded p-value is 1)
   if (round(pvalue, decimals) == 1) {
-    p <- paste0("$p > .", paste0(rep("9", decimals), collapse = ""), "$")
+    p <- paste0("p > .", paste0(rep("9", decimals), collapse = ""))
   }
   if (pvalue < 0.01 & decimals <= 2) {
-    p <- "$p < .01$"
+    p <- "p < .01"
   }
   if (pvalue < 0.001) {
-    p <- "$p < .001$"
+    p <- "p < .001"
   }
   if (numbers_only) {
     p <- gsub("p = ", "", p)
     p <- gsub("p ", "", p)
+    if (latex) p <- paste0("$", p, "$")
     return(p)
   }
+  if (latex) p <- paste0("$", p, "$")
   return(p)
 }

--- a/man/format_p.Rd
+++ b/man/format_p.Rd
@@ -4,7 +4,7 @@
 \alias{format_p}
 \title{Format a p-value according to APA standards}
 \usage{
-format_p(pvalues, decimals = 3, numbers_only = FALSE)
+format_p(pvalues, decimals = 3, numbers_only = FALSE, latex = TRUE)
 }
 \arguments{
 \item{pvalues}{The p-values}
@@ -12,8 +12,11 @@ format_p(pvalues, decimals = 3, numbers_only = FALSE)
 \item{decimals}{The number of decimals to be printed}
 
 \item{numbers_only}{Logical, indicates whether the p-values
-should be printed whithout the accompanying p.
+should be printed without the accompanying p.
 Defaults to \code{FALSE}.}
+
+\item{latex}{Logical, indicates whether the p-values should be printed with 
+or without \code{$} around it. Defaults to \code{TRUE}.}
 }
 \value{
 A string representation of the p value to be used in Rmarkdown
@@ -29,6 +32,7 @@ format_p(0.03123)
 format_p(0.000001231)
 format_p(0.000001231, decimals = 2)
 format_p(0.3123, decimals = 2)
+format_p(0.3123, latex = FALSE)
 # Format several p-values with one function call
 format_p(c(0.3123, 0.001, 0.00001, 0.19))
 format_p(c(.999, .9999, 1))


### PR DESCRIPTION
I suggest the argument `latex` for `format_p()`. It defaults to `TRUE`, leading to the previous behaviour where `$` are printed around the string by default, which is convenient for latex documents. When `FALSE`, the `$` are omitted, which is better for e.g. html documents.