### PR TITLE
Optional printing of confidence intervals for Cohen's d

### DIFF
--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -88,10 +88,10 @@ print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3, c
     if (confidence) {
       conf_int <- 
         paste0(
-          "$", d_object$CI * 100, "\\%$ $CI$ $[", force_decimals(d_object$CI_low), ", ", 
-          force_decimals(d_object$CI_high),  "]$"
+          "$", d_object$CI * 100, "\\%$ $CI$ $[", force_decimals(d_object$CI_low), 
+          "$, ", "$",force_decimals(d_object$CI_high),  "]$"
         )
-      return(cat(paste(t, p, d, conf_int, sep = ", ")))
+      return(paste(t, p, d, conf_int, sep = ", "))
     }
     
     return(paste(t, p, d, sep = ", "))

--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -41,7 +41,11 @@
 #' cd <- cohens_d(sleep$extra[sleep$group == 1], 
 #'                sleep$extra[sleep$group == 2], paired = TRUE)
 #' print_ttest(tt, cd)
-#' # Print the confidence interval (taken from the effectsize object):
+#' # Print the confidence interval
+#' print_ttest(tt, cd, confidence = TRUE)
+#' # The information about the CI is taken from the effectsize object:
+#' cd <- cohens_d(sleep$extra[sleep$group == 1], 
+#'                sleep$extra[sleep$group == 2], paired = TRUE, ci = .8)
 #' print_ttest(tt, cd, confidence = TRUE)
 #' # effect size object can be left out:
 #' print_ttest(tt)

--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -11,6 +11,9 @@
 #'     (defaults to 2).
 #' @param decimals_p How many decimals should be printed for the p-value
 #'     (defaults to 3).
+#' @param confidence Logical. Whether a confidence interval for the effectsize 
+#'     should be printed or not. Can only be \code{TRUE} if \code{d_object} is
+#'     provided.
 #'     
 #' @return A string describing the t-test; to be 
 #'     included in an R markdown document.
@@ -38,13 +41,15 @@
 #' cd <- cohens_d(sleep$extra[sleep$group == 1], 
 #'                sleep$extra[sleep$group == 2], paired = TRUE)
 #' print_ttest(tt, cd)
+#' # Print the 95% confidence interval:
+#' print_ttest(tt, cd, confidence = TRUE)
 #' # effect size object can be left out:
 #' print_ttest(tt)
 #'
 #' @author Martin Papenberg \email{martin.papenberg@@hhu.de}
 #' @export
 #'
-print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3) {
+print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3, confidence = FALSE) {
   validate_input(t_object, "t_object", "htest")
   if (!is.null(d_object)) {
     # Validate input
@@ -61,7 +66,10 @@ print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3) {
     if (t_paired != d_paired) {
       stop(paste0("t-test is ", t_paired, ", but Cohen's d is ", d_paired))
     }
+  } else {
+    if (confidence) stop("Cannot print confidence intervals when no d_object is provided.")
   }
+  
   validate_input(decimals, "decimals",  "numeric", 1, TRUE, TRUE)
   validate_input(decimals_p, "decimals_p", "numeric", 1, TRUE, TRUE)
   
@@ -72,7 +80,14 @@ print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3) {
     d <- "$d = "
     if (attr(d_object, "paired")) d <- "$d_z = "
     d <- paste0(d, force_decimals(d_object$Cohens_d, decimals), "$")
+    
+    if (confidence) {
+      conf_int <- paste0(d_object$CI * 100, "% CI [", force_decimals(d_object$CI_low), ", ", force_decimals(d_object$CI_high),  "]")
+      return(paste(t, p, d, conf_int, sep = ", "))
+      }
+    
     return(paste(t, p, d, sep = ", "))
   }
   return(paste(t, p, sep = ", "))
 }
+

--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -88,10 +88,10 @@ print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3, c
     if (confidence) {
       conf_int <- 
         paste0(
-          "$", d_object$CI * 100, "% CI [", force_decimals(d_object$CI_low), ", ", 
+          "$", d_object$CI * 100, "\\%$ $CI$ $[", force_decimals(d_object$CI_low), ", ", 
           force_decimals(d_object$CI_high),  "]$"
         )
-      return(paste(t, p, d, conf_int, sep = ", "))
+      return(cat(paste(t, p, d, conf_int, sep = ", ")))
     }
     
     return(paste(t, p, d, sep = ", "))

--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -86,9 +86,13 @@ print_ttest <- function(t_object, d_object = NULL, decimals=2, decimals_p = 3, c
     d <- paste0(d, force_decimals(d_object$Cohens_d, decimals), "$")
     
     if (confidence) {
-      conf_int <- paste0(d_object$CI * 100, "% CI [", force_decimals(d_object$CI_low), ", ", force_decimals(d_object$CI_high),  "]")
+      conf_int <- 
+        paste0(
+          "$", d_object$CI * 100, "% CI [", force_decimals(d_object$CI_low), ", ", 
+          force_decimals(d_object$CI_high),  "]$"
+        )
       return(paste(t, p, d, conf_int, sep = ", "))
-      }
+    }
     
     return(paste(t, p, d, sep = ", "))
   }

--- a/R/print_ttest.R
+++ b/R/print_ttest.R
@@ -41,7 +41,7 @@
 #' cd <- cohens_d(sleep$extra[sleep$group == 1], 
 #'                sleep$extra[sleep$group == 2], paired = TRUE)
 #' print_ttest(tt, cd)
-#' # Print the 95% confidence interval:
+#' # Print the confidence interval (taken from the effectsize object):
 #' print_ttest(tt, cd, confidence = TRUE)
 #' # effect size object can be left out:
 #' print_ttest(tt)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,15 @@ cd <- cohens_d(sleep$extra[sleep$group == 1],
 print_ttest(tt, cd)
 # "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$"
 
-# Print the confidence interval (taken from the effectsize object):
+# Print the confidence interval:
 print_ttest(tt, cd, confidence = TRUE)
+# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, 95% CI [-2.23, -0.44]"
+
+# The information about the CI is taken from the effectsize object:
+cd <- cohens_d(sleep$extra[sleep$group == 1], 
+               sleep$extra[sleep$group == 2], paired = TRUE, ci = .8)
+print_ttest(tt, cd, confidence = TRUE)
+# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, 80% CI [-1.91, -0.73]"
 
 # effect size object can be left out:
 print_ttest(tt)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ cd <- cohens_d(sleep$extra[sleep$group == 1],
 print_ttest(tt, cd)
 # "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$"
 
+# Print the confidence interval (taken from the effectsize object):
+print_ttest(tt, cd, confidence = TRUE)
+
 # effect size object can be left out:
 print_ttest(tt)
 # "$t(9) = -4.06$, $p = .003$"

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ print_ttest(tt, cd)
 
 # Print the confidence interval:
 print_ttest(tt, cd, confidence = TRUE)
-# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, 95% CI [-2.23, -0.44]"
+# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, $95\\%$ $CI$ $[-2.12$, $-0.41]$"
 
 # The information about the CI is taken from the effectsize object:
 cd <- cohens_d(sleep$extra[sleep$group == 1], 
                sleep$extra[sleep$group == 2], paired = TRUE, ci = .8)
 print_ttest(tt, cd, confidence = TRUE)
-# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, 80% CI [-1.91, -0.73]"
+# "$t(9) = -4.06$, $p = .003$, $d_z = -1.28$, $80\\%$ $CI$ $[-1.81$, $-0.70]$"
 
 # effect size object can be left out:
 print_ttest(tt)

--- a/man/print_ttest.Rd
+++ b/man/print_ttest.Rd
@@ -55,7 +55,11 @@ tt <- t.test(sleep$extra[sleep$group == 1],
 cd <- cohens_d(sleep$extra[sleep$group == 1], 
                sleep$extra[sleep$group == 2], paired = TRUE)
 print_ttest(tt, cd)
-# Print the confidence interval (taken from the effectsize object):
+# Print the confidence interval
+print_ttest(tt, cd, confidence = TRUE)
+# The information about the CI is taken from the effectsize object:
+cd <- cohens_d(sleep$extra[sleep$group == 1], 
+               sleep$extra[sleep$group == 2], paired = TRUE, ci = .8)
 print_ttest(tt, cd, confidence = TRUE)
 # effect size object can be left out:
 print_ttest(tt)

--- a/man/print_ttest.Rd
+++ b/man/print_ttest.Rd
@@ -4,7 +4,13 @@
 \alias{print_ttest}
 \title{Print the results of a t-test}
 \usage{
-print_ttest(t_object, d_object = NULL, decimals = 2, decimals_p = 3)
+print_ttest(
+  t_object,
+  d_object = NULL,
+  decimals = 2,
+  decimals_p = 3,
+  confidence = FALSE
+)
 }
 \arguments{
 \item{t_object}{An object of class "htest" returned by 
@@ -19,6 +25,10 @@ Optional argument.}
 
 \item{decimals_p}{How many decimals should be printed for the p-value
 (defaults to 3).}
+
+\item{confidence}{Logical. Whether a confidence interval for the effectsize 
+should be printed or not. Can only be \code{TRUE} if \code{d_object} is
+provided.}
 }
 \value{
 A string describing the t-test; to be 
@@ -45,6 +55,8 @@ tt <- t.test(sleep$extra[sleep$group == 1],
 cd <- cohens_d(sleep$extra[sleep$group == 1], 
                sleep$extra[sleep$group == 2], paired = TRUE)
 print_ttest(tt, cd)
+# Print the 95\% confidence interval:
+print_ttest(tt, cd, confidence = TRUE)
 # effect size object can be left out:
 print_ttest(tt)
 

--- a/man/print_ttest.Rd
+++ b/man/print_ttest.Rd
@@ -55,7 +55,7 @@ tt <- t.test(sleep$extra[sleep$group == 1],
 cd <- cohens_d(sleep$extra[sleep$group == 1], 
                sleep$extra[sleep$group == 2], paired = TRUE)
 print_ttest(tt, cd)
-# Print the 95\% confidence interval:
+# Print the confidence interval (taken from the effectsize object):
 print_ttest(tt, cd, confidence = TRUE)
 # effect size object can be left out:
 print_ttest(tt)


### PR DESCRIPTION
- The argument `confidence` (logical) in `print_ttest()` controls whether to report a confidence interval for Cohen's d (if an `d_object` is provided). Defaults to `FALSE`.
- Information about the effect size is directly taken from `d_object` (e.g., the width of the confidence interval).