### PR TITLE
Optional rounding to zero in force_decimals()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,4 @@ Suggests:
     spgs
 Encoding: UTF-8
 LazyLoad: yes
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/print_decimals_specified.R
+++ b/R/print_decimals_specified.R
@@ -3,24 +3,41 @@
 #'
 #' @param x the numeric values to be printed
 #' @param decimals how many decimals are to be printed. Defaults to 2.
+#' @param round_zero whether small values should be rounded to zero or whether 
+#'                   they should be displayed as e.g. < .01. See details. 
+#'                   Defaults to \code{TRUE}.
 #'
 #' @return The number in the required format
+#' 
+#' @details 
+#' 
+#' By default, \code{force_decimals()} will round numbers that are small enough 
+#' down to zero, e.g., 0.0004 will be rounded to 0.00. If 
+#' \code{round_zero = FALSE}, \code{force_decimals(0.0004)} will return 
+#' \code{"< 0.01"} instead. See examples.
 #'
 #' @examples
 #' 
 #' force_decimals(c(1.23456, 0.873, 2.3456))
 #' force_decimals(c(1.23456, 0.873, 2.3456), 3)
 #' 
+#' force_decimals(c(0.004, 0.001, 0.0005, 0.02))
+#' force_decimals(c(0.004, 0.001, 0.0005, 0.02), round_zero = FALSE)
+#' force_decimals(c(0.004, 0.001, 0.0005, 0.02), 3, round_zero = FALSE)
+#' 
 #' @author Martin Papenberg \email{martin.papenberg@@hhu.de}
 #' @export
 #'
-force_decimals <- function(x, decimals = 2) {
-  return(vectorize_print(x, decimals, force_decimals_))
+force_decimals <- function(x, decimals = 2, round_zero = TRUE) {
+  return(vectorize_print(x, decimals, force_decimals_, round_zero))
 }
 
-force_decimals_ <- function(x, decimals) {
+force_decimals_ <- function(x, decimals, round_zero) {
   if (is.na(x)) {
     return(NA_character_)
+  }
+  if (round(x, decimals) == 0 & !round_zero) {
+    return(paste0("< 0.", paste(rep("0", decimals - 1), collapse = ""), "1"))
   }
   return(format(round(x, decimals), nsmall = decimals, scientific = FALSE))
 }

--- a/README.md
+++ b/README.md
@@ -122,8 +122,15 @@ print_anova(aov_ez("id", "rt", md_12.1, within = c("angle", "noise"),
 ```R
 force_decimals(c(1.23456, 0.873, 2.3456), decimals = 2)
 # [1] "1.23" "0.87" "2.35"
-## Note that function `round` will not produce the same results as
+## Note that the function `round()` will not produce the same results as
 ## force_decimals in Rmd output
+
+force_decimals(c(0.004, 0.001, 0.0005, 0.02))
+# [1] "0.00" "0.00" "0.00" "0.02"
+## Small numbers are rounded to zero by default.
+## This behaviour can be controlled using the argument `round_zero`:
+force_decimals(c(0.004, 0.001, 0.0005, 0.02), round_zero = FALSE)
+# "< 0.01" "< 0.01" "< 0.01" "0.02"
 
 ## Leave integers intact:
 force_or_cut(c(1:3, 1.23456, 0.873, 2.3456), decimals = 2)

--- a/man/force_decimals.Rd
+++ b/man/force_decimals.Rd
@@ -4,12 +4,16 @@
 \alias{force_decimals}
 \title{Force printing a specified number of decimals for a number}
 \usage{
-force_decimals(x, decimals = 2)
+force_decimals(x, decimals = 2, round_zero = TRUE)
 }
 \arguments{
 \item{x}{the numeric values to be printed}
 
 \item{decimals}{how many decimals are to be printed. Defaults to 2.}
+
+\item{round_zero}{whether small values should be rounded to zero or whether 
+they should be displayed as e.g. < .01. See details. 
+Defaults to \code{TRUE}.}
 }
 \value{
 The number in the required format
@@ -17,10 +21,20 @@ The number in the required format
 \description{
 Force printing a specified number of decimals for a number
 }
+\details{
+By default, \code{force_decimals()} will round numbers that are small enough 
+down to zero, e.g., 0.0004 will be rounded to 0.00. If 
+\code{round_zero = FALSE}, \code{force_decimals(0.0004)} will return 
+\code{"< 0.01"} instead. See examples.
+}
 \examples{
 
 force_decimals(c(1.23456, 0.873, 2.3456))
 force_decimals(c(1.23456, 0.873, 2.3456), 3)
+
+force_decimals(c(0.004, 0.001, 0.0005, 0.02))
+force_decimals(c(0.004, 0.001, 0.0005, 0.02), round_zero = FALSE)
+force_decimals(c(0.004, 0.001, 0.0005, 0.02), 3, round_zero = FALSE)
 
 }
 \author{


### PR DESCRIPTION
Optional argument `round_zero` (default: `TRUE`) controls whether small numbers should be rounded to zero (e.g., `force_decimals(0.002)` will return `"0.00"`) or not (e.g., `force_decimals(0.002, round_zero = FALSE)` will return `"< 0.01"`).